### PR TITLE
Fix build failure on MinGW-w64

### DIFF
--- a/libnpk/CMakeLists.txt
+++ b/libnpk/CMakeLists.txt
@@ -34,11 +34,9 @@ set( NPK_SRCS_DEV_MODE
     ./src/npk_dev.c
 )
 
-if( WIN32 )
-    if( NOT CMAKE_CL_64 )
-        add_definitions( -D_USE_32BIT_TIME_T )
-    endif( NOT CMAKE_CL_64 )
-endif( WIN32 )
+if( NOT CMAKE_SIZEOF_VOID_P EQUAL 8 )
+    add_definitions( -D_USE_32BIT_TIME_T )
+endif( NOT CMAKE_SIZEOF_VOID_P EQUAL 8 )
 
 if( USE_ZLIB_PREFIX )
     add_definitions( -DZ_PREFIX )

--- a/libnpk/include/npk_conf.h
+++ b/libnpk/include/npk_conf.h
@@ -38,7 +38,9 @@
 
 #if defined(_WIN32) || defined(_WIN64)
     #define NPK_PLATFORM_WINDOWS
- 	typedef int mode_t;
+    #ifndef _MODE_T_
+        typedef int mode_t;
+    #endif
 #elif defined(linux) || defined(__linux) || defined(__linux__)
     #define NPK_PLATFORM_LINUX
 #elif defined(__FreeBSD__)

--- a/libnpk/tests/testutil.h
+++ b/libnpk/tests/testutil.h
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <fcntl.h>
+#include <malloc.h>
 #if defined( WIN32 )
 #include <io.h>
 #pragma warning ( disable : 4819 )


### PR DESCRIPTION
- Resolves #11
  - [x] MinGW-w64-x86-64
  - [x] MinGW-w64-i686

Tested using [dockcross](https://github.com/dockcross/dockcross) to simulate environments.
```base
docker run --rm dockcross/windows-x86 > ./dockcross
chmod +x ./dockcross
rm -rf _build/ && ./dockcross ./build.sh
```